### PR TITLE
Only dependency is xml-simple as CSV and NET HTTP is part of Ruby

### DIFF
--- a/salesforce_bulk.gemspec
+++ b/salesforce_bulk.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |s|
   # s.add_development_dependency "rspec"
   # s.add_runtime_dependency "rest-client"
 
-  #s.add_development_dependency "net-http"
-  #s.add_development_dependency "xmlsimple"
-  #s.add_development_dependency "csv"
+  s.add_dependency "xml-simple"
 
 end


### PR DESCRIPTION
Updated the gemspec file as we need to specify the xml-simple gem as a dependency otherwise we get errors since the gem isn't installed as a dependency when including salesforce_bulk in a Gemfile. Removed CSV and NET HTTP as they are part of Ruby. Correct me though if they do need to be specified.
