### PR TITLE
Fix regex to account for 2 numbers in instance name, e.g. na12

### DIFF
--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -81,7 +81,7 @@ module SalesforceBulk
     end
 
     def parse_instance()
-      @server_url =~ /https:\/\/([a-z]{2,2}[0-9]{1,1})-api/
+      @server_url =~ /https:\/\/([a-z]{2,2}[0-9]{1,2})-api/
       @instance = $~.captures[0]
     end
 


### PR DESCRIPTION
I received an error that "captures" was a missing method and figured out the problem was with the regex that parses the instance name. The instance name on my end included 2 numbers: na12. The regex was coded to assume only 1. I think though the regex should look for anything after "https://" and before "-api" rather than a fixed set of characters as that's how its described in the API documentation: http://www.salesforce.com/us/developer/docs/api_asynch/Content/asynch_api_batches_get_info_all.htm
