### PR TITLE
Fix close job action

### DIFF
--- a/lib/salesforce_bulk.rb
+++ b/lib/salesforce_bulk.rb
@@ -1,4 +1,4 @@
-require 'net/http'
+require 'net/https'
 require 'xmlsimple'
 require 'csv'
 require "salesforce_bulk/version"

--- a/lib/salesforce_bulk.rb
+++ b/lib/salesforce_bulk.rb
@@ -49,10 +49,9 @@ module SalesforceBulk
       end
       job.close_job()
 
-      state = job.check_batch_status()
       while true
-        #puts "\nstate is #{state}\n"
         state = job.check_batch_status()
+        #puts "\nstate is #{state}\n"
         if state != "Queued"
           break
         end

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -82,7 +82,7 @@ module SalesforceBulk
     end
 
     def parse_instance()
-      @server_url =~ /https:\/\/([a-z]{2,2}[0-9]{1,1})-api/
+      @server_url =~ /https:\/\/([a-z]{2,2}[0-9]{1,2})-api/
       @instance = $~.captures[0]
     end
 

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -4,10 +4,9 @@ module SalesforceBulk
 
     @@XML_HEADER = '<?xml version="1.0" encoding="utf-8" ?>'
     @@API_VERSION = nil
-    @@LOGIN_HOST = 'login.salesforce.com'
     @@INSTANCE_HOST = nil # Gets set in login()
 
-    def initialize(username, password, api_version)
+    def initialize(username, password, api_version, opts={})
       @username = username
       @password = password
       @session_id = nil
@@ -16,7 +15,8 @@ module SalesforceBulk
       @@API_VERSION = api_version
       @@LOGIN_PATH = "/services/Soap/u/#{@@API_VERSION}"
       @@PATH_PREFIX = "/services/async/#{@@API_VERSION}/"
-
+      @@LOGIN_HOST  = "#{opts[:test] ? 'test' : 'live'}.salesforce.com"
+      
       login()
     end
 
@@ -60,10 +60,7 @@ module SalesforceBulk
 
       #puts "#{host} -- #{path} -- #{headers.inspect}\n"
 
-      http = Net::HTTP.new(host)
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      resp = http.post(path, xml, headers)
-      return resp.body
+      https(host).post(path, xml, headers).body
     end
 
     def get_request(host, path, headers)
@@ -74,10 +71,14 @@ module SalesforceBulk
         headers['X-SFDC-Session'] = @session_id;
       end
 
-      http = Net::HTTP.new(host)
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      resp = http.get(path, headers)
-      return resp.body
+      https(host).get(path, headers).body
+    end
+
+    def https(host)
+      req = Net::HTTP.new(host, 443)
+      req.use_ssl = true
+      req.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      req
     end
 
     def parse_instance()

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -15,7 +15,7 @@ module SalesforceBulk
       @@API_VERSION = api_version
       @@LOGIN_PATH = "/services/Soap/u/#{@@API_VERSION}"
       @@PATH_PREFIX = "/services/async/#{@@API_VERSION}/"
-      @@LOGIN_HOST  = "#{opts[:test] ? 'test' : 'live'}.salesforce.com"
+      @@LOGIN_HOST  = "#{opts[:test] ? 'test' : 'login'}.salesforce.com"
       
       login()
     end

--- a/lib/salesforce_bulk/job.rb
+++ b/lib/salesforce_bulk/job.rb
@@ -34,7 +34,7 @@ module SalesforceBulk
 
     def close_job()
       xml = "#{@@XML_HEADER}<jobInfo xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">"
-      xml += "state>Closed</state>"
+      xml += "<state>Closed</state>"
       xml += "</jobInfo>"
 
       path = "job/#{@@job_id}"

--- a/salesforce_bulk.gemspec
+++ b/salesforce_bulk.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   # s.add_development_dependency "rspec"
   # s.add_runtime_dependency "rest-client"
 
-  s.add_dependency "xmlsimple"
-  s.add_dependency "csv"
+  s.add_dependency "xml-simple"
 
 end

--- a/salesforce_bulk.gemspec
+++ b/salesforce_bulk.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
   # s.add_development_dependency "rspec"
   # s.add_runtime_dependency "rest-client"
 
-  #s.add_development_dependency "net-http"
-  #s.add_development_dependency "xmlsimple"
-  #s.add_development_dependency "csv"
+  s.add_development_dependency "net-http"
+  s.add_development_dependency "xmlsimple"
+  s.add_development_dependency "csv"
 
 end

--- a/salesforce_bulk.gemspec
+++ b/salesforce_bulk.gemspec
@@ -22,8 +22,7 @@ Gem::Specification.new do |s|
   # s.add_development_dependency "rspec"
   # s.add_runtime_dependency "rest-client"
 
-  s.add_development_dependency "net-http"
-  s.add_development_dependency "xmlsimple"
-  s.add_development_dependency "csv"
+  s.add_dependency "xmlsimple"
+  s.add_dependency "csv"
 
 end


### PR DESCRIPTION
The XML payload in the close job action had an invalid start status tag (was missing '<'). I was going to make some other close job related changes in the do_operation method in salesforce_bulk.rb but realized I misunderstood how that is supposed to work. Instead I just removed the first check batch status call outside the while loop as its unnecessary. Inside the while loop its the first action performed.
