### PR TITLE
Fix close job action

### DIFF
--- a/lib/salesforce_bulk.rb
+++ b/lib/salesforce_bulk.rb
@@ -49,10 +49,9 @@ module SalesforceBulk
       end
       job.close_job()
 
-      state = job.check_batch_status()
       while true
-        #puts "\nstate is #{state}\n"
         state = job.check_batch_status()
+        #puts "\nstate is #{state}\n"
         if state != "Queued"
           break
         end

--- a/lib/salesforce_bulk/job.rb
+++ b/lib/salesforce_bulk/job.rb
@@ -34,7 +34,7 @@ module SalesforceBulk
 
     def close_job()
       xml = "#{@@XML_HEADER}<jobInfo xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">"
-      xml += "state>Closed</state>"
+      xml += "<state>Closed</state>"
       xml += "</jobInfo>"
 
       path = "job/#{@@job_id}"


### PR DESCRIPTION
The XML payload in the close job action had an invalid start status tag (was missing '<'). I was going to make some other close job related changes in the do_operation method in salesforce_bulk.rb but realized I misunderstood how that is supposed to work. Instead I just removed the first check batch status call outside the while loop as its unnecessary. Inside the while loop its the first action performed.
