### PR TITLE
Get rid of -api in regular expression for SalesforceBulk::Connection.parse_instance()

### DIFF
--- a/lib/salesforce_bulk.rb
+++ b/lib/salesforce_bulk.rb
@@ -62,13 +62,19 @@ module SalesforceBulk
         else
           job.result.message = "There is an error in your job. The response returned a state of #{state}. Please check your query/parameters and try again."
           job.result.success = false
+          self.dbdc_query records # retry query when descriptive error message when error happened
           return job
-
         end
       else
         return job
       end
 
+    end
+
+    def dbdc_query soql
+      client = Databasedotcom::Client.new(host: @connection.info[:host], verify_mode:  OpenSSL::SSL::VERIFY_NONE)
+      client.authenticate token: @connection.info[:token], instance_url: @connection.info[:instance_url]
+      client.query soql
     end
 
     def parse_batch_result result

--- a/lib/salesforce_bulk.rb
+++ b/lib/salesforce_bulk.rb
@@ -62,7 +62,7 @@ module SalesforceBulk
         else
           job.result.message = "There is an error in your job. The response returned a state of #{state}. Please check your query/parameters and try again."
           job.result.success = false
-          self.dbdc_query records # retry query when descriptive error message when error happened
+          self.dbdc_query records if operation == 'query' # retry query when descriptive error message when error happened
           return job
         end
       else

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -21,6 +21,12 @@ module SalesforceBulk
       login()
     end
 
+    def info
+      { host: @@LOGIN_HOST,
+        instance_url: @server_url,
+        token: @session_id}
+    end
+
     #private
 
     def login()

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -81,7 +81,7 @@ module SalesforceBulk
     end
 
     def parse_instance()
-      @server_url =~ /https:\/\/([a-z]{2,2}[0-9]{1,2})-api/
+      @server_url =~ /https:\/\/([a-z]{2,2}[0-9]{1,2})/
       @instance = $~.captures[0]
     end
 

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -87,8 +87,7 @@ module SalesforceBulk
     end
 
     def parse_instance()
-      @server_url =~ /https:\/\/([a-z0-9]+)/
-      @instance = $~.captures[0]
+      @instance = URI(@server_url).host.sub(".salesforce.com", "")
     end
 
     def parse_response response

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -42,7 +42,7 @@ module SalesforceBulk
       xml += "    </n1:login>"
       xml += "  </env:Body>"
       xml += "</env:Envelope>"
-      
+
       headers = Hash['Content-Type' => 'text/xml; charset=utf-8', 'SOAPAction' => 'login']
 
       response = post_xml(@@LOGIN_HOST, @@LOGIN_PATH, xml, headers)
@@ -87,7 +87,7 @@ module SalesforceBulk
     end
 
     def parse_instance()
-      @server_url =~ /https:\/\/([a-z]{2,2}[0-9]{1,2})/
+      @server_url =~ /https:\/\/([a-z0-9]+)/
       @instance = $~.captures[0]
     end
 
@@ -96,7 +96,7 @@ module SalesforceBulk
 
       if response.downcase.include?("faultstring") || response.downcase.include?("exceptionmessage")
         begin
-          
+
           if response.downcase.include?("faultstring")
             error_message = response_parsed["Body"][0]["Fault"][0]["faultstring"][0]
           elsif response.downcase.include?("exceptionmessage")

--- a/salesforce_bulk.gemspec
+++ b/salesforce_bulk.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
   # s.add_runtime_dependency "rest-client"
 
   s.add_dependency "xml-simple"
+  s.add_dependency "databasedotcom-rails"
 
 end


### PR DESCRIPTION
Salesforce used to have a -api after the instance name and no longer
does.
