### PR TITLE
Regex Problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .bundle
 Gemfile.lock
 pkg/*
+.project
+*~

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -81,11 +81,9 @@ module SalesforceBulk
     end
 
     def parse_instance()
-      #@server_url =~ /https:\/\/([a-z]{2,2}[0-9]{1,2})-api/
-      #@instance = $~.captures[0]
-      #TODO: JOHN RYAN: had to do this fix quick after a Salesforce API change
-      puts 'Bypassing regex for sfdc URI'
-      @server_url = @instance
+      # Removed "-api" from URI
+      @server_url =~ /https:\/\/([a-z]{2,2}[0-9]{1,2})/
+      @instance = $~.captures[0]
     end
 
     def parse_response response

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -83,7 +83,8 @@ module SalesforceBulk
     def parse_instance()
       #@server_url =~ /https:\/\/([a-z]{2,2}[0-9]{1,2})-api/
       #@instance = $~.captures[0]
-      # JOHN RYAN: had to do this fix quick after a Salesforce API change
+      #TODO: JOHN RYAN: had to do this fix quick after a Salesforce API change
+      puts 'Bypassing regex for sfdc URI'
       @server_url = @instance
     end
 

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -81,8 +81,10 @@ module SalesforceBulk
     end
 
     def parse_instance()
-      @server_url =~ /https:\/\/([a-z]{2,2}[0-9]{1,2})-api/
-      @instance = $~.captures[0]
+      #@server_url =~ /https:\/\/([a-z]{2,2}[0-9]{1,2})-api/
+      #@instance = $~.captures[0]
+      # JOHN RYAN: had to do this fix quick after a Salesforce API change
+      @server_url = @instance
     end
 
     def parse_response response

--- a/lib/salesforce_bulk/job.rb
+++ b/lib/salesforce_bulk/job.rb
@@ -82,7 +82,17 @@ module SalesforceBulk
       response = @@connection.post_xml(nil, path, output_csv, headers)
       response_parsed = XmlSimple.xml_in(response)
 
-      @@batch_id = response_parsed['id'][0]
+      if response_parsed['id'] == nil
+        exceptionMessage = response_parsed['exceptionMessage']
+        if (exceptionMessage == nil)
+          problemMessage = 'no exceptionMessage returned'
+        else
+            problemMessage = exceptionMessage.join(',')
+        end
+        raise "Could not add a batch to the bulk job id=#{@@job_id}: #{problemMessage}"
+      else
+        @@batch_id = response_parsed['id'][0]
+      end
     end
 
     def check_batch_status()

--- a/lib/salesforce_bulk/version.rb
+++ b/lib/salesforce_bulk/version.rb
@@ -1,3 +1,3 @@
 module SalesforceBulk
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end

--- a/lib/salesforce_bulk/version.rb
+++ b/lib/salesforce_bulk/version.rb
@@ -1,3 +1,3 @@
 module SalesforceBulk
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end

--- a/lib/salesforce_bulk/version.rb
+++ b/lib/salesforce_bulk/version.rb
@@ -1,3 +1,3 @@
 module SalesforceBulk
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end

--- a/lib/salesforce_bulk/version.rb
+++ b/lib/salesforce_bulk/version.rb
@@ -1,3 +1,3 @@
 module SalesforceBulk
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/lib/salesforce_bulk/version.rb
+++ b/lib/salesforce_bulk/version.rb
@@ -1,3 +1,3 @@
 module SalesforceBulk
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/lib/salesforce_bulk_quickfix.rb
+++ b/lib/salesforce_bulk_quickfix.rb
@@ -1,0 +1,3 @@
+# This was created as a quickfix to handle backward compatibility where the 
+# salesforce_bulk gem could not be removed from a server
+require 'salesforce_bulk'

--- a/salesforce_bulk.gemspec
+++ b/salesforce_bulk.gemspec
@@ -3,15 +3,15 @@ $:.push File.expand_path("../lib", __FILE__)
 require "salesforce_bulk/version"
 
 Gem::Specification.new do |s|
-  s.name        = "salesforce_bulk"
+  s.name        = "salesforce_bulk_quickfix"
   s.version     = SalesforceBulk::VERSION
-  s.authors     = ["Jorge Valdivia"]
-  s.email       = ["jorge@valdivia.me"]
+  s.authors     = ["Jorge Valdivia, John Ryan"]
+  s.email       = ["jorge@valdivia.me;johnny@patchapps.com"]
   s.homepage    = "https://github.com/jorgevaldivia/salesforce_bulk"
   s.summary     = %q{Ruby support for the Salesforce Bulk API}
   s.description = %q{This gem provides a super simple interface for the Salesforce Bulk API. It provides support for insert, update, upsert, delete, and query.}
 
-  s.rubyforge_project = "salesforce_bulk"
+  s.rubyforge_project = "salesforce_bulk_quickfix"
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
After this quarters salesforce update, the regex in connection.rb in parse_instance is incorrect.

I forked to https://github.com/patchapps/salesforce_bulk and had to publish the gem as https://rubygems.org/gems/salesforce_bulk_quickfix to get us back online.

As soon as it's fixed in the main, I'll delete my forks and repo.
