### PR TITLE
Support Custom Domains

### DIFF
--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -84,7 +84,7 @@ module SalesforceBulk
       regexps = [
         /https:\/\/([a-z]{2,2}[0-9]{1,2})(-api)?/,
         /https:\/\/[a-zA-Z\-0-9]*.([a-z]{2,2}[0-9]{1,2})(-api)?/,
-        /https:\/\/([a-zA-Z\-0-9]*.my)?/
+        /https:\/\/([a-zA-Z\-0-9]*\.my)/
       ]
 
       for r in regexps

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -89,7 +89,7 @@ module SalesforceBulk
 
       for r in regexps
         m = r.match(@server_url)
-        return m.caputures[0] if m
+        return m.captures[0] if m
       end
 
       raise "Unable to parse Salesforce instance from server url (#{@server_url})."

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -81,18 +81,19 @@ module SalesforceBulk
     end
 
     def parse_instance()
-      @server_url =~ /https:\/\/([a-z]{2,2}[0-9]{1,2})(-api)?/
-      if $~.nil?
-        # Check for a "My Domain" subdomain
-        @server_url =~ /https:\/\/[a-zA-Z\-0-9]*.([a-z]{2,2}[0-9]{1,2})(-api)?/
-        if $~.nil?
-          raise "Unable to parse Salesforce instance from server url (#{@server_url})."
-        else
-          @instance = $~.captures[0]
-        end
-      else
-        @instance = $~.captures[0]
+      regexps = [
+        /https:\/\/([a-z]{2,2}[0-9]{1,2})(-api)?/,
+        /https:\/\/[a-zA-Z\-0-9]*.([a-z]{2,2}[0-9]{1,2})(-api)?/,
+        /https:\/\/([a-zA-Z\-0-9]*.my)?/
+      ]
+
+      for r in regexps
+        m = r.match(@server_url)
+        return m.caputures[0] if m
       end
+
+      raise "Unable to parse Salesforce instance from server url (#{@server_url})."
+
     end
 
     def parse_response response


### PR DESCRIPTION
By allowing the regular expression matcher in parse_instance to match custom domains we can use API endpoints with a custom domain defined.
