### PR TITLE
Ihs 19694 salesforce bulk gem completely disables ssl verify mode 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .bundle
 Gemfile.lock
 pkg/*
+.idea/*

--- a/README.rdoc
+++ b/README.rdoc
@@ -3,6 +3,8 @@
 ==Overview
 
 Salesforce bulk is a simple ruby gem for connecting to and using the Salesforce Bulk API (http://www.salesforce.com/us/developer/docs/api_asynch/index.htm). There are already some gems out there that provide connectivity to the Salesforce SOAP and Rest APIs, if your needs are simple, I recommend using those, specifically raygao's asf-rest-adapter (https://github.com/raygao/asf-rest-adapter) or databasedotcom (https://rubygems.org/gems/databasedotcom).
+
+This is a modified version of the original gem, which allows you to pass in an existing auth_token and organization_id from a previously authenticated API (such as Restforce).  This allows for server-side OAuth flow where a username and password is not readily available.
  
 ==Installation
 
@@ -14,13 +16,18 @@ Using this gem is simple and straight forward.
 
 To initialize:
 
+  Minimum signature:
   require 'salesforce_bulk'
-  salesforce = SalesforceBulk::Api.new("YOUR_SALESFORCE_USERNAME", "YOUR_SALESFORCE_PASSWORD+YOUR_SALESFORCE_TOKEN")
+  salesforce = SalesforceBulk::Api.new("EXISTING_AUTH_TOKEN", "SF_INSTANCE_DOMAIN", "YOUR_ORG_ID")
+  
+  Full signature:
+  salesforce = SalesforceBulk::Api.new("EXISTING_AUTH_TOKEN", "SF_INSTANCE_DOMAIN", "YOUR_ORG_ID", "API_VERSION", false)
+  
+  Where SF_INSTANCE_DOMAIN is the "na12" portion of the instance URL: "https://na12.salesforce.com"
 
 To use sandbox:
-  salesforce = SalesforceBulk::Api.new("YOUR_SALESFORCE_SANDBOX_USERNAME", "YOUR_SALESFORCE_PASSWORD+YOUR_SALESFORCE_SANDBOX_TOKEN", true)
+  salesforce = SalesforceBulk::Api.new("EXISTING_AUTH_TOKEN", "SF_INSTANCE_DOMAIN", "YOUR_ORG_ID", "API_VERSION", true)
 
-Note: the second parameter is a combination of your Salesforce token and password. So if your password is xxxx and your token is yyyy, the second parameter will be xxxxyyyy
 
 Sample operations:
 

--- a/lib/salesforce_bulk.rb
+++ b/lib/salesforce_bulk.rb
@@ -9,7 +9,7 @@ module SalesforceBulk
   # Your code goes here...
   class Api
 
-    SALESFORCE_API_VERSION = '24.0'.freeze
+    SALESFORCE_API_VERSION = '47.0'.freeze
 
     def initialize(sid, instance, orgid, api_version, in_sandbox=false)
       api_version ||= SALESFORCE_API_VERSION

--- a/lib/salesforce_bulk.rb
+++ b/lib/salesforce_bulk.rb
@@ -12,7 +12,8 @@ module SalesforceBulk
     @@SALESFORCE_API_VERSION = '24.0'
 
     def initialize(sid, instance, orgid, api_version, in_sandbox=false)
-      @connection = SalesforceBulk::Connection.new(sid, instance, orgid, @@SALESFORCE_API_VERSION, in_sandbox)
+      api_version ||= @@SALESFORCE_API_VERSION
+      @connection = SalesforceBulk::Connection.new(sid, instance, orgid, api_version, in_sandbox)
     end
 
     def upsert(sobject, records, external_field, wait=false)

--- a/lib/salesforce_bulk.rb
+++ b/lib/salesforce_bulk.rb
@@ -9,10 +9,10 @@ module SalesforceBulk
   # Your code goes here...
   class Api
 
-    @@SALESFORCE_API_VERSION = '24.0'
+    SALESFORCE_API_VERSION = '24.0'.freeze
 
     def initialize(sid, instance, orgid, api_version, in_sandbox=false)
-      api_version ||= @@SALESFORCE_API_VERSION
+      api_version ||= SALESFORCE_API_VERSION
       @connection = SalesforceBulk::Connection.new(sid, instance, orgid, api_version, in_sandbox)
     end
 

--- a/lib/salesforce_bulk.rb
+++ b/lib/salesforce_bulk.rb
@@ -11,8 +11,8 @@ module SalesforceBulk
 
     @@SALESFORCE_API_VERSION = '24.0'
 
-    def initialize(username, password, in_sandbox=false)
-      @connection = SalesforceBulk::Connection.new(username, password, @@SALESFORCE_API_VERSION, in_sandbox)
+    def initialize(sid, instance, orgid, api_version, in_sandbox=false)
+      @connection = SalesforceBulk::Connection.new(sid, instance, orgid, @@SALESFORCE_API_VERSION, in_sandbox)
     end
 
     def upsert(sobject, records, external_field, wait=false)

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -46,7 +46,6 @@ module SalesforceBulk
     def https(host)
       req = Net::HTTP.new(host, 443)
       req.use_ssl = true
-      req.verify_mode = OpenSSL::SSL::VERIFY_NONE
       req
     end
 

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -7,7 +7,7 @@ module SalesforceBulk
     @@LOGIN_HOST = 'login.salesforce.com'
     @@INSTANCE_HOST = nil # Gets set in login()
 
-    def initialize(sid, instance, orgid, api_version, in_sandbox = nil)
+    def initialize(sid, instance, orgid, api_version, in_sandbox)
       @session_id = sid
       @instance = instance
       @server_url = "https://#{instance}.salesforce.com/services/Soap/u/28.0/#{orgid}"

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -20,6 +20,14 @@ module SalesforceBulk
 
       login()
     end
+    
+    # Used when a restforce client is used for making the initial connection
+    def set_session_info(sid, instance, orgid)
+      @session_id = sid
+      @instance = instance
+      @server_url = "https://#{instance}.salesforce.com/services/Soap/u/28.0/#{orgid}"
+      @@INSTANCE_HOST = "#{@instance}.salesforce.com"
+    end
 
     #private
 

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -26,7 +26,7 @@ module SalesforceBulk
       @session_id = sid
       @instance = instance
       @server_url = "https://#{instance}.salesforce.com/services/Soap/u/28.0/#{orgid}"
-      @@INSTANCE_HOST = "#{@instance}.salesforce.com"
+      @@INSTANCE_HOST = "#{instance}.salesforce.com"
     end
 
     #private

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -2,40 +2,41 @@ module SalesforceBulk
 
   class Connection
 
-    @@XML_HEADER = '<?xml version="1.0" encoding="utf-8" ?>'
-    @@API_VERSION = nil
-    @@LOGIN_HOST = 'login.salesforce.com'
-    @@INSTANCE_HOST = nil # Gets set in login()
+    XML_HEADER = '<?xml version="1.0" encoding="utf-8" ?>'.freeze
+    LOGIN_HOST = 'login.salesforce.com'.freeze
+    SANDBOX_LOGIN_HOST = 'test.salesforce.com'.freeze
+
+    attr_accessor :session_id
 
     def initialize(sid, instance, orgid, api_version, in_sandbox)
       @session_id = sid
       @instance = instance
       @server_url = "https://#{instance}.salesforce.com/services/Soap/u/28.0/#{orgid}"
-      @@INSTANCE_HOST = "#{instance}.salesforce.com"
-      @@API_VERSION = api_version
-      @@LOGIN_PATH = "/services/Soap/u/#{@@API_VERSION}"
-      @@PATH_PREFIX = "/services/async/#{@@API_VERSION}/"
-      @@LOGIN_HOST = 'test.salesforce.com' if in_sandbox
+      @instance_url = "#{instance}.salesforce.com"
+      @api_version = api_version
+      @login_path = "/services/Soap/u/#{@api_version}"
+      @path_prefix = "/services/async/#{@api_version}/"
+      @login_host =  in_sandbox ? SANDBOX_LOGIN_HOST : LOGIN_HOST
     end
 
     #private
     def post_xml(host, path, xml, headers)
 
-      host = host || @@INSTANCE_HOST
+      host = host || @instance_url
 
-      if host != @@LOGIN_HOST # Not login, need to add session id to header
-        headers['X-SFDC-Session'] = @session_id;
-        path = "#{@@PATH_PREFIX}#{path}"
+      if host != @login_host # Not login, need to add session id to header
+        headers['X-SFDC-Session'] = @session_id
+        path = "#{@path_prefix}#{path}"
       end
 
       https(host).post(path, xml, headers).body
     end
 
     def get_request(host, path, headers)
-      host = host || @@INSTANCE_HOST
-      path = "#{@@PATH_PREFIX}#{path}"
+      host = host || @instance_url
+      path = "#{@path_prefix}#{path}"
 
-      if host != @@LOGIN_HOST # Not login, need to add session id to header
+      if host != @login_host # Not login, need to add session id to header
         headers['X-SFDC-Session'] = @session_id;
       end
 

--- a/lib/salesforce_bulk/connection.rb
+++ b/lib/salesforce_bulk/connection.rb
@@ -7,57 +7,18 @@ module SalesforceBulk
     @@LOGIN_HOST = 'login.salesforce.com'
     @@INSTANCE_HOST = nil # Gets set in login()
 
-    def initialize(username, password, api_version, in_sandbox)
-      @username = username
-      @password = password
-      @session_id = nil
-      @server_url = nil
-      @instance = nil
-      @@API_VERSION = api_version
-      @@LOGIN_PATH = "/services/Soap/u/#{@@API_VERSION}"
-      @@PATH_PREFIX = "/services/async/#{@@API_VERSION}/"
-      @@LOGIN_HOST = 'test.salesforce.com' if in_sandbox
-
-      login()
-    end
-    
-    # Used when a restforce client is used for making the initial connection
-    def set_session_info(sid, instance, orgid)
+    def initialize(sid, instance, orgid, api_version, in_sandbox = nil)
       @session_id = sid
       @instance = instance
       @server_url = "https://#{instance}.salesforce.com/services/Soap/u/28.0/#{orgid}"
       @@INSTANCE_HOST = "#{instance}.salesforce.com"
+      @@API_VERSION = api_version
+      @@LOGIN_PATH = "/services/Soap/u/#{@@API_VERSION}"
+      @@PATH_PREFIX = "/services/async/#{@@API_VERSION}/"
+      @@LOGIN_HOST = 'test.salesforce.com' if in_sandbox
     end
 
     #private
-
-    def login()
-
-      xml = '<?xml version="1.0" encoding="utf-8" ?>'
-      xml += "<env:Envelope xmlns:xsd=\"http://www.w3.org/2001/XMLSchema\""
-      xml += "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
-      xml += "    xmlns:env=\"http://schemas.xmlsoap.org/soap/envelope/\">"
-      xml += "  <env:Body>"
-      xml += "    <n1:login xmlns:n1=\"urn:partner.soap.sforce.com\">"
-      xml += "      <n1:username>#{@username}</n1:username>"
-      xml += "      <n1:password>#{@password}</n1:password>"
-      xml += "    </n1:login>"
-      xml += "  </env:Body>"
-      xml += "</env:Envelope>"
-      
-      headers = Hash['Content-Type' => 'text/xml; charset=utf-8', 'SOAPAction' => 'login']
-
-      response = post_xml(@@LOGIN_HOST, @@LOGIN_PATH, xml, headers)
-      # response_parsed = XmlSimple.xml_in(response)
-      response_parsed = parse_response response
-
-      @session_id = response_parsed['Body'][0]['loginResponse'][0]['result'][0]['sessionId'][0]
-      @server_url = response_parsed['Body'][0]['loginResponse'][0]['result'][0]['serverUrl'][0]
-      @instance = parse_instance()
-
-      @@INSTANCE_HOST = "#{@instance}.salesforce.com"
-    end
-
     def post_xml(host, path, xml, headers)
 
       host = host || @@INSTANCE_HOST

--- a/lib/salesforce_bulk/job.rb
+++ b/lib/salesforce_bulk/job.rb
@@ -2,16 +2,21 @@ module SalesforceBulk
 
   class Job
 
-    attr :result
+    attr_reader :result,
+                :job_id,
+                :batch_id,
+                :operation,
+                :sobject,
+                :records
 
+    XML_HEADER = '<?xml version="1.0" encoding="utf-8" ?>'.freeze
     def initialize(operation, sobject, records, external_field, connection)
 
-      @@operation = operation
-      @@sobject = sobject
-      @@external_field = external_field
-      @@records = records
-      @@connection = connection
-      @@XML_HEADER = '<?xml version="1.0" encoding="utf-8" ?>'
+      @operation = operation
+      @sobject = sobject
+      @external_field = external_field
+      @records = records
+      @connection = connection
 
       # @result = {"errors" => [], "success" => nil, "records" => [], "raw" => nil, "message" => 'The job has been queued.'}
       @result = JobResult.new
@@ -19,11 +24,11 @@ module SalesforceBulk
     end
 
     def create_job()
-      xml = "#{@@XML_HEADER}<jobInfo xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">"
-      xml += "<operation>#{@@operation}</operation>"
-      xml += "<object>#{@@sobject}</object>"
-      if !@@external_field.nil? # This only happens on upsert
-        xml += "<externalIdFieldName>#{@@external_field}</externalIdFieldName>"
+      xml = "#{XML_HEADER}<jobInfo xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">"
+      xml += "<operation>#{@operation}</operation>"
+      xml += "<object>#{@sobject}</object>"
+      if !@external_field.nil? # This only happens on upsert
+        xml += "<externalIdFieldName>#{@external_field}</externalIdFieldName>"
       end
       xml += "<contentType>CSV</contentType>"
       xml += "</jobInfo>"
@@ -31,42 +36,42 @@ module SalesforceBulk
       path = "job"
       headers = Hash['Content-Type' => 'application/xml; charset=utf-8']
 
-      response = @@connection.post_xml(nil, path, xml, headers)
-      response_parsed = @@connection.parse_response response
+      response = @connection.post_xml(nil, path, xml, headers)
+      response_parsed = @connection.parse_response response
 
-      @@job_id = response_parsed['id'][0]
+      @job_id = response_parsed['id'][0]
     end
 
     def close_job()
-      xml = "#{@@XML_HEADER}<jobInfo xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">"
+      xml = "#{XML_HEADER}<jobInfo xmlns=\"http://www.force.com/2009/06/asyncapi/dataload\">"
       xml += "<state>Closed</state>"
       xml += "</jobInfo>"
 
-      path = "job/#{@@job_id}"
+      path = "job/#{@job_id}"
       headers = Hash['Content-Type' => 'application/xml; charset=utf-8']
 
-      response = @@connection.post_xml(nil, path, xml, headers)
+      response = @connection.post_xml(nil, path, xml, headers)
       response_parsed = XmlSimple.xml_in(response)
 
       #job_id = response_parsed['id'][0]
     end
 
     def add_query
-      path = "job/#{@@job_id}/batch/"
+      path = "job/#{@job_id}/batch/"
       headers = Hash["Content-Type" => "text/csv; charset=UTF-8"]
       
-      response = @@connection.post_xml(nil, path, @@records, headers)
+      response = @connection.post_xml(nil, path, @records, headers)
       response_parsed = XmlSimple.xml_in(response)
 
-      @@batch_id = response_parsed['id'][0]
+      @batch_id = response_parsed['id'][0]
     end
 
     def add_batch()
-      keys = @@records.first.keys
+      keys = @records.first.keys
       
       output_csv = keys.to_csv
 
-      @@records.each do |r|
+      @records.each do |r|
         fields = Array.new
         keys.each do |k|
           fields.push(r[k])
@@ -76,20 +81,20 @@ module SalesforceBulk
         output_csv += row_csv
       end
 
-      path = "job/#{@@job_id}/batch/"
+      path = "job/#{@job_id}/batch/"
       headers = Hash["Content-Type" => "text/csv; charset=UTF-8"]
       
-      response = @@connection.post_xml(nil, path, output_csv, headers)
+      response = @connection.post_xml(nil, path, output_csv, headers)
       response_parsed = XmlSimple.xml_in(response)
 
-      @@batch_id = response_parsed['id'][0]
+      @batch_id = response_parsed['id'][0]
     end
 
     def check_batch_status()
-      path = "job/#{@@job_id}/batch/#{@@batch_id}"
+      path = "job/#{@job_id}/batch/#{@batch_id}"
       headers = Hash.new
 
-      response = @@connection.get_request(nil, path, headers)
+      response = @connection.get_request(nil, path, headers)
       response_parsed = XmlSimple.xml_in(response)
 
       begin
@@ -103,20 +108,20 @@ module SalesforceBulk
     end
 
     def get_batch_result()
-      path = "job/#{@@job_id}/batch/#{@@batch_id}/result"
+      path = "job/#{@job_id}/batch/#{@batch_id}/result"
       headers = Hash["Content-Type" => "text/xml; charset=UTF-8"]
 
-      response = @@connection.get_request(nil, path, headers)
+      response = @connection.get_request(nil, path, headers)
 
-      if(@@operation == "query") # The query op requires us to do another request to get the results
+      if(@operation == "query") # The query op requires us to do another request to get the results
         response_parsed = XmlSimple.xml_in(response)
         result_id = response_parsed["result"][0]
 
-        path = "job/#{@@job_id}/batch/#{@@batch_id}/result/#{result_id}"
+        path = "job/#{@job_id}/batch/#{@batch_id}/result/#{result_id}"
         headers = Hash.new
         headers = Hash["Content-Type" => "text/xml; charset=UTF-8"]
         
-        response = @@connection.get_request(nil, path, headers)
+        response = @connection.get_request(nil, path, headers)
 
       end
 
@@ -132,7 +137,7 @@ module SalesforceBulk
       csvRows = CSV.parse(response, :headers => true)
 
       csvRows.each_with_index  do |row, index|
-        if @@operation != "query"
+        if @operation != "query"
           row["Created"] = row["Created"] == "true" ? true : false
           row["Success"] = row["Success"] == "true" ? true : false
         end

--- a/lib/salesforce_bulk/version.rb
+++ b/lib/salesforce_bulk/version.rb
@@ -1,3 +1,3 @@
 module SalesforceBulk
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end

--- a/lib/salesforce_bulk/version.rb
+++ b/lib/salesforce_bulk/version.rb
@@ -1,3 +1,3 @@
 module SalesforceBulk
-  VERSION = "1.0.2"
+  VERSION = "1.0.3"
 end


### PR DESCRIPTION
### Summary of Changes

- Bumped the current SFDC API version to 47.0 from 24
- Changed the gem version to 1.04 from 1.03
- Removed the verify_mode being set to VERIFY_NONE

**JIRA Link**: https://introhive.atlassian.net/browse/IHS-19694

Testing:
modify your GEM file to use the new gem

            gem 'salesforce_bulk', github: 'introhive/salesforce_bulk', branch: 'IHS-19694_salesforce_bulk_gem_completely_disables_SSL_verify_mode_2', require: false

From the console
- locate a crm details to use ( SFDC ) 

          crm_details = CrmDetails.find <id>

-  Create one of the following delayed jobs 

          Delayed::Job.enqueue(SalesforceEnqueueBulkUpdateContactsJob.new(crm_details), priority: SalesforceHelper::JOB_PRIORITIES[:enqueue_bulk_update], queue:'salesforce')

          Delayed::Job.enqueue(SalesforceEnqueueBulkUpdateLeadsJob.new(crm_details), priority: SalesforceHelper::JOB_PRIORITIES[:enqueue_bulk_update], queue:'salesforce')if crm_details.leads_enabled?

          Delayed::Job.enqueue(SalesforceBulkUpdateUsersJob.new(crm_details), priority: SalesforceHelper::JOB_PRIORITIES[:update_user_details], queue:'salesforce')

Run the delayed job and verify it didn't fail 
